### PR TITLE
Fix linux version capture

### DIFF
--- a/web/services/run_playwright_script.py
+++ b/web/services/run_playwright_script.py
@@ -119,11 +119,19 @@ def run_playwright_script(task_config: list) -> tuple:
                                 break
 
                     elif action == "find_and_extract_download_link":
-                        print("🔍 Buscando botão com texto:", step["text_contains"])
+                        text_field = step.get("text_contains")
+                        if isinstance(text_field, str):
+                            text_options = [text_field]
+                        elif isinstance(text_field, list):
+                            text_options = text_field
+                        else:
+                            raise ValueError("text_contains must be a string or list of strings")
+
+                        print("🔍 Buscando botão com texto:", text_options)
                         buttons = page.query_selector_all("button")
                         for btn in buttons:
                             inner = btn.inner_text()
-                            if step["text_contains"] in inner:
+                            if any(option in inner for option in text_options):
                                 with page.expect_download() as download_info:
                                     btn.click()
                                 download = download_info.value

--- a/web/tests/test_capture_latest_pec_version.py
+++ b/web/tests/test_capture_latest_pec_version.py
@@ -32,7 +32,7 @@ def test_extrair_link_esus():
         },
         {
             "action": "wait_for_selector",
-            "selector": "button:has-text(\"Versão para Linux\")"
+            "selector": "button:has-text(\"para Linux\")"
         },
         {
             "action": "capture_current_url",
@@ -40,7 +40,7 @@ def test_extrair_link_esus():
         },
         {
             "action": "find_and_extract_download_link",
-            "text_contains": "Versão para Linux",
+            "text_contains": ["Versão para Linux", "Download para Linux"],
             "store_as": "link_linux"
         }
     ]


### PR DESCRIPTION
## Summary
- allow `find_and_extract_download_link` to accept multiple text options
- make capture test robust to new 'Download para Linux' wording

## Testing
- `pytest -q` *(fails: BrowserType.launch: Executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_688c18a8e9308321b530e9615e42cb1d